### PR TITLE
chore: update storage paths for Antigravity IDE and bump version to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antigravity-skill-to-workflow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antigravity-skill-to-workflow",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/KerrYang56/Antigravity-S2W.git"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "engines": {
     "vscode": "^1.90.0"
   },

--- a/src/services/AnthropicSkillsInstaller.ts
+++ b/src/services/AnthropicSkillsInstaller.ts
@@ -20,8 +20,8 @@ export class AnthropicSkillsInstaller {
 
   constructor() {
     this.homeDir = os.homedir();
-    this.skillsDir = path.join(this.homeDir, ".gemini", "antigravity", "skills");
-    this.workflowsDir = path.join(this.homeDir, ".gemini", "antigravity", "global_workflows");
+    this.skillsDir = path.join(this.homeDir, ".gemini", "antigravity-ide", "skills");
+    this.workflowsDir = path.join(this.homeDir, ".gemini", "config", "global_workflows");
     this.tempDir = path.join(this.homeDir, ".antigravity", "anthropic-temp");
   }
 

--- a/src/services/PathManager.ts
+++ b/src/services/PathManager.ts
@@ -135,8 +135,8 @@ export class PathManager {
     switch (this.targetAgent) {
       case "gemini":
         return this.installMode === "global"
-          ? path.join(base, ".gemini", "antigravity", "global_workflows")
-          : path.join(base, ".gemini", "antigravity", "workflows");
+          ? path.join(base, ".gemini", "config", "global_workflows")
+          : path.join(base, ".gemini", "antigravity-ide", "workflows");
       case "github":
         return path.join(base, ".github");
       case "agents":
@@ -149,6 +149,11 @@ export class PathManager {
   }
 
   public getSkillsPath(): string {
+    if (this.targetAgent === "gemini") {
+      return this.installMode === "global"
+        ? path.join(this.getBasePath(), ".gemini", "antigravity-ide", "skills")
+        : path.join(this.getBasePath(), ".gemini", "skills");
+    }
     return path.join(this.getBasePath(), `.${this.targetAgent}`, "skills");
   }
 }

--- a/src/services/SuperpowersInstaller.ts
+++ b/src/services/SuperpowersInstaller.ts
@@ -20,8 +20,8 @@ export class SuperpowersInstaller {
 
   constructor() {
     this.homeDir = os.homedir();
-    this.skillsDir = path.join(this.homeDir, ".gemini", "antigravity", "skills");
-    this.workflowsDir = path.join(this.homeDir, ".gemini", "antigravity", "global_workflows");
+    this.skillsDir = path.join(this.homeDir, ".gemini", "antigravity-ide", "skills");
+    this.workflowsDir = path.join(this.homeDir, ".gemini", "config", "global_workflows");
     this.tempDir = path.join(this.homeDir, ".antigravity", "superpowers-temp");
   }
 

--- a/src/services/UiUxProMaxInstaller.ts
+++ b/src/services/UiUxProMaxInstaller.ts
@@ -51,10 +51,10 @@ Please read and internalize the skill documentation located at:
 
   constructor() {
     this.homeDir = os.homedir();
-    // Default location: .gemini/antigravity/skills
-    this.skillsDir = path.join(this.homeDir, ".gemini", "antigravity", "skills");
+    // Default location: .gemini/antigravity-ide/skills
+    this.skillsDir = path.join(this.homeDir, ".gemini", "antigravity-ide", "skills");
     this.destSkillDir = path.join(this.skillsDir, "ui-ux-pro-max");
-    this.workflowsDir = path.join(this.homeDir, ".gemini", "antigravity", "global_workflows");
+    this.workflowsDir = path.join(this.homeDir, ".gemini", "config", "global_workflows");
   }
 
   public isInstalled(): boolean {


### PR DESCRIPTION
- Update App Data directory from `~/.gemini/antigravity` to `~/.gemini/antigravity-ide`
- Move global workflows output directory to `~/.gemini/config/global_workflows`
- Update `PathManager` and installer configurations (`SuperpowersInstaller`, `AnthropicSkillsInstaller`, `UiUxProMaxInstaller`) to use the new paths
- Bump extension version from 0.5.0 to 0.5.1 in package.json